### PR TITLE
Set _isNoSession to true always if not the first instance

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -330,10 +330,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 	if (nppGUI._multiInstSetting == multiInst)
 	{
 		isMultiInst = true;
-		// Only the first launch remembers the session
-		if (!TheFirstOne)
-			cmdLineParams._isNoSession = true;
 	}
+
+	// Only the first launch remembers the session
+	if (!TheFirstOne)
+		cmdLineParams._isNoSession = true;
 
 	generic_string quotFileName = TEXT("");
     // tell the running instance the FULL path to the new files to load


### PR DESCRIPTION
Closes #2856

I made a pull request just to make it clear that it's trivial to fix.

I'm not really familiar with the code base though, or even with C++, and haven't tested it, so you'd better give it a check before accepting it.

I would still much rather have multiple instances in session.xml supported, of course, but in the meanwhile this will save some people.